### PR TITLE
msm: mdss: Power on display asynchronously as early as possible

### DIFF
--- a/drivers/video/fbdev/msm/mdss_dsi.h
+++ b/drivers/video/fbdev/msm/mdss_dsi.h
@@ -591,6 +591,13 @@ struct mdss_dsi_ctrl_pdata {
 	bool update_phy_timing; /* flag to recalculate PHY timings */
 
 	bool phy_power_off;
+
+	struct notifier_block wake_notif;
+	struct task_struct *wake_thread;
+	struct completion wake_comp;
+	wait_queue_head_t wake_waitq;
+	atomic_t needs_wake;
+	bool is_unblank;
 };
 
 struct dsi_status_data {

--- a/drivers/video/fbdev/msm/mdss_mdp_ctl.c
+++ b/drivers/video/fbdev/msm/mdss_mdp_ctl.c
@@ -27,6 +27,7 @@
 #include "mdss_mdp.h"
 #include "mdss_mdp_trace.h"
 #include "mdss_debug.h"
+#include "mdss_dsi.h"
 
 #define MDSS_MDP_QSEED3_VER_DOWNSCALE_LIM 2
 #define NUM_MIXERCFG_REGS 3
@@ -4227,6 +4228,15 @@ int mdss_mdp_ctl_destroy(struct mdss_mdp_ctl *ctl)
 	return 0;
 }
 
+static void mdss_mdp_wait_for_panel_on(struct mdss_panel_data *pdata)
+{
+	struct mdss_dsi_ctrl_pdata *ctrl_pdata =
+		container_of(pdata, typeof(*ctrl_pdata), panel_data);
+
+	if (atomic_read(&ctrl_pdata->needs_wake))
+		wait_for_completion(&ctrl_pdata->wake_comp);
+}
+
 int mdss_mdp_ctl_intf_event(struct mdss_mdp_ctl *ctl, int event, void *arg,
 	u32 flags)
 {
@@ -4250,8 +4260,11 @@ int mdss_mdp_ctl_intf_event(struct mdss_mdp_ctl *ctl, int event, void *arg,
 	pr_debug("sending ctl=%d event=%d flag=0x%x\n", ctl->num, event, flags);
 
 	do {
-		if (pdata->event_handler)
+		if (pdata->event_handler) {
 			rc = pdata->event_handler(pdata, event, arg);
+			if (event == MDSS_EVENT_LINK_READY)
+				mdss_mdp_wait_for_panel_on(pdata);
+		}
 		pdata = pdata->next;
 	} while (rc == 0 && pdata && pdata->active &&
 		!(flags & CTL_INTF_EVENT_FLAG_SKIP_BROADCAST));

--- a/drivers/video/fbdev/msm/mdss_mdp_overlay.c
+++ b/drivers/video/fbdev/msm/mdss_mdp_overlay.c
@@ -5740,10 +5740,6 @@ static int mdss_mdp_overlay_on(struct msm_fb_data_type *mfd)
 		rc = mdss_mdp_overlay_start(mfd);
 		if (rc)
 			goto end;
-		if (mfd->panel_info->type != WRITEBACK_PANEL) {
-			atomic_inc(&mfd->mdp_sync_pt_data.commit_cnt);
-			rc = mdss_mdp_overlay_kickoff(mfd, NULL);
-		}
 	} else {
 		rc = mdss_mdp_ctl_setup(ctl);
 		if (rc)


### PR DESCRIPTION
Currently, mdss powers on the display a long time after an unblank is
requested and gets completely blocked while powering on the display, so if
the display takes a very long time to turn on, then mdss will be stuck
unable to do anything else in the meantime. This results in a long delay
between trying to wake the device and the display actually powering on
and rendering a frame.

In order to make the display turn on faster when waking the device from
sleep, start powering on the display as soon as the framebuffer unblank
event is received. This allows mdss to continue resuming while the display
takes its time powering on. A high-priority kthread is used here to ensure
the display powers on as quickly as possible.

To make this work, kickoffs need to be blocked when they attempt to power
on the display, so that a kickoff won't continue while the display is
still powered off. Additionally, in order to maximize speed benefits, the
redundant kickoff in mdss_mdp_overlay_on() needs to be removed since it'd
block mdss prematurely while waiting for the display to power on. This
kickoff is redundant because the display thread will kickoff upon receiving
the first frame after unblank anyway, so it's safe to remove.

Change-Id: I55617edf8a8c7424b5f887a8080174d329846271
Signed-off-by: Sultan Alsawaf <sultanxda@gmail.com>